### PR TITLE
Check if plugin is installed before installing

### DIFF
--- a/tasks/setup_wp_plugins.yml
+++ b/tasks/setup_wp_plugins.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install plugins for instance '{{ wp_instance.name | mandatory }}'
   become_user: www-data
-  command: "wp plugin install {{ item.name }} --path={{ wordpress_instance_path }} --activate"
+  shell: "wp plugin is-installed {{ item.name }} --path={{ wordpress_instance_path }} || wp plugin install {{ item.name }} --path={{ wordpress_instance_path }} --activate"
   register: output
   changed_when: "'Installing' in output.stdout"
   loop: "{{ wp_instance.plugins | default(wordpress_default_plugins) }}"


### PR DESCRIPTION
I encoutered a plugin that can't be updated without a licence (only indirectly through theme updates). if I try to update the plugin with wp cli I get the following error:

```
$ wp plugin install <plugin-name>
…
Warning: Installationspaket nicht verfügbar.                                                                           
Error: No plugins installed.
```

Even though calling `wp plugin is-installed <plugin-name>` tells me the plugin is indeed installed.

This requires a minor change to the plugin installation routine.