### PR TITLE
chore(mysql_db): Ansible 2.10 compatibility for mysql_db

### DIFF
--- a/tasks/setup_wp_database.yml
+++ b/tasks/setup_wp_database.yml
@@ -7,7 +7,7 @@
   no_log: True
 
 - name: Create a new database with name '{{ wp_instance.database_name | default(wp_instance.name) }}'
-  mysql_db:
+  community.mysql.mysql_db:
     name: "{{ wordpress_mysql_database_name }}"
     encoding: utf8
 
@@ -48,7 +48,7 @@
     when: wp_instance.import_db_file | default(wordpress_default_import_db_file)
 
   - name: Import WordPress SQL file for instance '{{ wp_instance.name | mandatory }}'
-    mysql_db:
+    community.mysql.mysql_db:
       state: import
       name: "{{ wordpress_mysql_database_name }}"
       target: "{{ wp_sql_file.path }}"


### PR DESCRIPTION
Since Ansible 2.10, `mysql_db` is no longer a part of Ansible. It can be obtained from the Ansible Galaxy collection `community.mysql`. Note that this change probably breaks compatibility with Ansible <= 2.8.