### PR TITLE
fix(database): Fix bug that causes failure in role when using unix socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This role requires the [php-fpm role](https://github.com/stuvusIT/php-fpm), the 
 
 ## Role Variables
 
-The role has one top-level variable `wordpress_instances`, which is a list of dicts:
+The role has one main top-level variable `wordpress_instances`, which is a list of dicts.
+Additionally there are some global defaults (see `defaults/main.yaml`).
 
 ### General
 
@@ -41,15 +42,16 @@ The variables described in the [defaults](defaults/main.yml) are used as default
 
 ### Database connection
 
-| Name                | Required/Default                        | Description                                          |
-| ------------------- | --------------------------------------- | ---------------------------------------------------- |
-| `mysql_host`        | `localhost:/var/run/mysqld/mysqld.sock` |
-| `mysql_user`        | `{{instance.name}}`                     | The MySQL user to use for this instance              |
-| `mysql_create_user` | `True`                                  | Whether to create the MySQL user if it doesn't exist |
-| `mysql_db`          | `{{instance.name}}`                     | The database to create and use for this instance     |
-| `mysql_create_db`   | `True`                                  | Whether to create the database if it doesn't exist   |
-| `mysql_password`    | :heavy_check_mark:                      | The password for the MySQL user                      |
-| `table_prefix`      | `wp_`                                   | The database to create and use for this instance     |
+| Name                | Required/Default                          | Description                                                                                     |
+| ------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `mysql_host`        | `localhost`                               |
+| `mysql_user`        | `{{instance.name}}`                       | The MySQL user to use for this instance                                                         |
+| `mysql_create_user` | `True`                                    | Whether to create the MySQL user if it doesn't exist                                            |
+| `mysql_db`          | `{{instance.name}}`                       | The database to create and use for this instance                                                |
+| `mysql_create_db`   | `True`                                    | Whether to create the database if it doesn't exist                                              |
+| `mysql_password`    | :heavy_check_mark:                        | The password for the MySQL user                                                                 |
+| `mysql_unix_socket` | `{{wordpress_default_mysql_unix_socket}}` | The unix socket to use for connecting to the database. Set to `null` for using tcp connections. |
+| `table_prefix`      | `wp_`                                     | The database to create and use for this instance                                                |
 
 ### Mail
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 wordpress_instances: []
 
+wordpress_default_mysql_unix_socket: '/var/run/mysqld/mysqld.sock'
+
 wordpress_default_table_prefix: "wp_"
 wordpress_default_import_wp_content: False
 wordpress_default_import_template: False

--- a/tasks/setup_wp_database.yml
+++ b/tasks/setup_wp_database.yml
@@ -17,6 +17,7 @@
   shell: >
     mysql
     --host={{ wordpress_mysql_host }}
+    {% if wordpress_mysql_unix_socket %} --socket={{ wordpress_mysql_unix_socket }}{% endif %}
     --user={{ wordpress_mysql_user }}
     --password={{ wordpress_mysql_password }}
     --database={{ wordpress_mysql_db }} -e "show tables;"
@@ -57,6 +58,7 @@
       login_host: "{{ wordpress_mysql_host }}"
       login_user: "{{ wordpress_mysql_user }}"
       login_password: "{{ wordpress_mysql_password }}"
+      login_unix_socket: "{{ wordpress_mysql_unix_socket }}"
       name: "{{ wordpress_mysql_db }}"
       target: "{{ wp_sql_file.path }}"
 
@@ -66,6 +68,3 @@
       state: absent
 
   when: wp_tables.stdout == ""
-
-
-

--- a/tasks/setup_wp_instance.yml
+++ b/tasks/setup_wp_instance.yml
@@ -1,6 +1,7 @@
 ---
 - set_fact:
-    wordpress_mysql_host: "{{ wp_instance.mysql_host | default('localhost:/var/run/mysqld/mysqld.sock') }}"
+    wordpress_mysql_host: "{{ wp_instance.mysql_host | default('localhost') }}"
+    wordpress_mysql_unix_socket: "{{ wp_instance.mysql_unix_socket | default(wordpress_default_mysql_unix_socket) }}"
     wordpress_mysql_user: "{{ wp_instance.mysql_user | default(wp_instance.name | mandatory) }}"
     wordpress_mysql_db: "{{ wp_instance.mysql_db | default(wp_instance.name | mandatory) }}"
     wordpress_mysql_password: "{{ wp_instance.mysql_password | mandatory }}"

--- a/templates/wp-config.php.j2
+++ b/templates/wp-config.php.j2
@@ -6,7 +6,7 @@
 define('DB_NAME', '{{ wordpress_mysql_db }}');
 define('DB_USER', '{{ wordpress_mysql_user }}');
 define('DB_PASSWORD', '{{ wordpress_mysql_password }}');
-define('DB_HOST', '{{ wordpress_mysql_host }}');
+define('DB_HOST', '{{ wordpress_mysql_host }}{% if wordpress_mysql_unix_socket %}:{{ wordpress_mysql_unix_socket }}{% endif %}');
 define('DB_CHARSET', 'utf8');
 define('DB_COLLATE', '');
 


### PR DESCRIPTION
The task Check if DB ... contains any tables failed when
a unix socket (the default) was used.

This bug was introduced by b390159 (#35)