### PR TITLE
fix(install_packages): Remove legacy package

### DIFF
--- a/tasks/install_packages.yml
+++ b/tasks/install_packages.yml
@@ -3,7 +3,6 @@
   apt:
     name:
       - php-mysql
-      - python-mysqldb
       - python3-mysqldb
       - php-ldap
       - php-imagick


### PR DESCRIPTION
It is no longer shipped with modern debian and causes errors