### PR TITLE
fix(download): Only download the wordpress code once

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,13 @@
       name: ''
       host: localhost
       state: absent
+  - name: Download latest WordPress version to localhost
+    get_url:
+      url: https://wordpress.org/latest.tar.gz
+      dest: "{{ global_cache_dir | mandatory }}/wordpress_latest.tar.gz"
+    become: False
+    delegate_to: localhost
+    run_once: True
   when: wordpress_instances | length > 0
 
 - include_tasks: setup_wp_instance.yml

--- a/tasks/setup_wp_directory.yml
+++ b/tasks/setup_wp_directory.yml
@@ -1,12 +1,4 @@
 ---
-- name: Download latest WordPress version to localhost
-  get_url:
-    url: https://wordpress.org/latest.tar.gz
-    dest: "{{ global_cache_dir | mandatory }}/wordpress_latest.tar.gz"
-  become: False
-  delegate_to: localhost
-  run_once: True
-
 - name: Create WordPress directory {{ wordpress_instance_path }}
   file:
     path: "{{ wordpress_instance_path }}"


### PR DESCRIPTION
Currently we hit a rate limit when running the role with to many instances