### PR TITLE
feat(plugins): ignore errors during update

### DIFF
--- a/tasks/setup_wp_plugins.yml
+++ b/tasks/setup_wp_plugins.yml
@@ -16,7 +16,9 @@
   command: wp plugin update --all --exclude={{ wp_instance.plugins | default(wordpress_default_plugins) | json_query(query_plugins_to_exclude) | join(',') }} --path={{ wordpress_instance_path }}
   vars:
     query_plugins_to_exclude: "[?contains(keys(@), 'update')] | [?!update].name"
+  ignore_errors: true
 
 - name: Update themes for instance '{{ wp_instance.name | mandatory }}'
   become_user: www-data
   command: wp theme update --all --path={{ wordpress_instance_path }}
+  ignore_errors: true


### PR DESCRIPTION
This allows the role to finish, even if the user of a wordpress instance installs a plugin, that will not update automatically.