### PR TITLE
fixes for the external DB case

### DIFF
--- a/tasks/install_packages.yml
+++ b/tasks/install_packages.yml
@@ -10,3 +10,4 @@
       - php-mbstring
       - php-curl
       - php-xml
+      - mariadb-client

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,11 +2,6 @@
 - block:
   - import_tasks: install_packages.yml
   - import_tasks: install_wp_cli.yml
-  - name: Remove anonymous DB user account
-    mysql_user:
-      name: ''
-      host: localhost
-      state: absent
   - name: Download latest WordPress version to localhost
     get_url:
       url: https://wordpress.org/latest.tar.gz


### PR DESCRIPTION
- Install mariadb-client. In a setup with MariaDB on the same VM, the client comes together with mariadb-server, but in a setup with external DB, this normally isn't installed automatically.
- Remove "Remove anonymous DB user account" task which assumes a local DB. This task doesn't really belong in the wordpress role, anyway, because that user has nothing to do with wordpress.